### PR TITLE
Add format function to package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,22 @@ This program produces this output: ::
     {'key1': 'value1'}
     {'key2': 'value2'}
 
+
+Easily generate lines in `logfmt` formatted output ::
+
+    from logfmt import format
+
+    for log_line in format({'key1': 'value1'}, {'key2': 'value2'})::
+        print log_line
+
+
+This program produces this output: ::
+    
+    key1="value1"
+    key2="value2"
+
+
+
 Installation
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Easily generate lines in `logfmt` formatted output ::
 
     from logfmt import format
 
-    for log_line in format({'key1': 'value1'}, {'key2': 'value2'})::
+    for log_line in format({'key1': 'value1'}, {'key2': 'value2'}):
         print log_line
 
 

--- a/logfmt/__init__.py
+++ b/logfmt/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 flake8:noqa -*-
 from logfmt.parser import parse_line
-
+from logfmt.formatter import format_line
 
 def parse(stream):
     for line in stream:

--- a/logfmt/__init__.py
+++ b/logfmt/__init__.py
@@ -7,3 +7,11 @@ def parse(stream):
         values = parse_line(line)
         if values:
             yield values
+
+# Will take in a list of hashes. Each call will generate a string for the next argument
+def format(*args):
+   for hash in args:
+       output = format_line(hash)
+       if output:
+           yield output
+

--- a/logfmt/formatter.py
+++ b/logfmt/formatter.py
@@ -1,6 +1,6 @@
 def format_line(hash):
   outarr = []
-  for k,v in hash.iteritems():
+  for k,v in hash.items():
     if v is None:
       outarr.append("%s=" % k)
       continue

--- a/logfmt/formatter.py
+++ b/logfmt/formatter.py
@@ -1,0 +1,25 @@
+def format_line(hash):
+  outarr = []
+  for k,v in hash.iteritems():
+    if v is None:
+      outarr.append("%s=" % k)
+      continue
+
+    if isinstance(v, bool):
+        v = "true" if v else "false"
+
+    elif isinstance(v, (int, long, float) ):
+        pass
+
+    else:
+      if isinstance(v, (dict, object)):
+        v = str(v)
+
+      v = '"%s"' % v.replace('"', '\\' + '"')
+    
+    outarr.append("%s=%s" % (k, v))
+
+  return " ".join(outarr)
+
+
+

--- a/logfmt/formatter.py
+++ b/logfmt/formatter.py
@@ -1,3 +1,5 @@
+import numbers
+
 def format_line(hash):
   outarr = []
   for k,v in hash.items():
@@ -8,7 +10,7 @@ def format_line(hash):
     if isinstance(v, bool):
         v = "true" if v else "false"
 
-    elif isinstance(v, (int, long, float) ):
+    elif isinstance(v, numbers.Number ):
         pass
 
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = logfmt
-version = 0.1
+version = 0.1.1
 author = Timothee Peignier
 author-email = timothee.peignier@tryphon.org
 summary = Parse log lines in the logfmt style.

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -26,10 +26,9 @@ class FormatterTestCase(TestCase):
     def test_float_value(self):
         data = format_line( OrderedDict([("key1", 342.23424), ("key2", -234234234.2342342)]) )
         
-	if sys.version_info < (3, 0):
+        if sys.version_info < (3, 0):
             self.assertEqual(data, "key1=342.23424 key2=-234234234.234")
         else:
-            234234234.2342342
             self.assertEqual(data, "key1=342.23424 key2=-234234234.2342342")
 
     # Essentially, pre format your floats to strings

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -2,6 +2,8 @@
 from logfmt.formatter import format_line
 from unittest import TestCase
 from collections import OrderedDict
+import sys
+
 
 class FormatterTestCase(TestCase):
     def test_empty_log_line(self):
@@ -20,10 +22,15 @@ class FormatterTestCase(TestCase):
         data = format_line( OrderedDict([("key1", -1), ("key2", 2342342)]) )
         self.assertEqual(data, "key1=-1 key2=2342342")
 
-    # By default, truncated to 12 digits total
+    # In python 2.7, truncated to 12 digits total.  3.x does 16 
     def test_float_value(self):
         data = format_line( OrderedDict([("key1", 342.23424), ("key2", -234234234.2342342)]) )
-        self.assertEqual(data, "key1=342.23424 key2=-234234234.234")
+        
+	if sys.version_info < (3, 0):
+            self.assertEqual(data, "key1=342.23424 key2=-234234234.234")
+        else:
+            234234234.2342342
+            self.assertEqual(data, "key1=342.23424 key2=-234234234.2342342")
 
     # Essentially, pre format your floats to strings
     def test_custom_float_format(self):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from logfmt.formatter import format_line
+from unittest import TestCase
+from collections import OrderedDict
+
+class FormatterTestCase(TestCase):
+    def test_empty_log_line(self):
+        data = format_line({})
+        self.assertEqual(data, "")
+
+    def test_key_without_value(self):
+        data = format_line( OrderedDict([("key1", None), ("key2", None)]) )
+        self.assertEqual(data, "key1= key2=")
+
+    def test_boolean_values(self):
+        data = format_line(OrderedDict([("key1", True), ("key2", False)])) 
+        self.assertEqual(data, "key1=true key2=false")
+
+    def test_int_value(self):
+        data = format_line( OrderedDict([("key1", -1), ("key2", 2342342)]) )
+        self.assertEqual(data, "key1=-1 key2=2342342")
+
+    # By default, truncated to 12 digits total
+    def test_float_value(self):
+        data = format_line( OrderedDict([("key1", 342.23424), ("key2", -234234234.2342342)]) )
+        self.assertEqual(data, "key1=342.23424 key2=-234234234.234")
+
+    # Essentially, pre format your floats to strings
+    def test_custom_float_format(self):
+        data = format_line( OrderedDict([
+            ("key1", 342.23424),
+            ("key2", "%.7f" % -234234234.2342342)
+        ]))
+
+        self.assertEqual(data, "key1=342.23424 key2=\"-234234234.2342342\"")
+
+    def test_string_value(self):
+        data = format_line( OrderedDict([
+            ("key1", """some random !@#$%^"&**_+-={}\\|;':,./<>?)"""),
+            ("key2", """here's a line with
+more stuff on the next""")
+        ]))
+
+        self.assertEqual(data, '''key1="some random !@#$%^\\"&**_+-={}\\|;\':,./<>?)" key2="here\'s a line with\nmore stuff on the next"''')
+
+
+


### PR DESCRIPTION
Rather than having every python developer have to properly format their log data with custom formatting code, this logfmt-python project can be imported and used.  If the library gets updates in speed/bug fixes, etc, then the whole community will benefit.

Thanks
