### PR TITLE
Single character value characters at the end of a line are misinterpreted

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -64,3 +64,7 @@ class ParserTestCase(TestCase):
     def test_pair_with_empty_quote(self):
         data = parse_line('key=""')
         self.assertEqual(data, {'key': ""})
+
+    def test_single_character_value_at_end_of_string(self):
+        data = parse_line('key=a')
+        self.assertEqual(data, {'key': 'a'})


### PR DESCRIPTION
```
>>> logfmt.parse_line('key=a')
{'key': True}
```

Currently just a failing test to illustrate the problem. I'm going to see if I can dig in and fix the bug, but the big state machine is currently making my brain melt slightly. Any pointers would be much appreciated.
